### PR TITLE
Add GitHub Pages deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -13,15 +13,8 @@ Currently uses mock data in `src/data/mb_carnival.json`.
 1. Create a **public** GitHub repo, e.g. `hoops-hub-murray-bridge`
 2. In `vite.config.js`, set `base` to `'/hoops-hub-murray-bridge/'` (must match your repo name with leading/trailing slashes)
 3. Commit and push the project
-4. Build: `npm run build` (creates `dist/`)
-5. Publish `dist/` to Pages. Easiest: install `gh-pages` (`npm i -D gh-pages`) and add scripts to package.json:
-   ```json
-   "scripts": {
-     "predeploy": "npm run build",
-     "deploy": "gh-pages -d dist"
-   }
-   ```
-   Then run: `npm run deploy`
+4. Install dependencies (includes `gh-pages`): `npm install`
+5. Deploy to Pages: `npm run deploy` (builds the site and publishes `dist/` to the `gh-pages` branch)
 6. In GitHub, Settings → Pages → set branch to `gh-pages`. Your site will be at `https://<username>.github.io/<repo>/`
 
 ### B) Netlify

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "lucide-react": "^0.453.0",
@@ -15,6 +17,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "gh-pages": "^6.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add gh-pages as a dev dependency and wire predeploy/deploy npm scripts
- document the simplified GitHub Pages workflow in the README and ignore build artifacts

## Testing
- not run (Node.js tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68e314e3029c8327a2df0e5a66e2f08b