### PR TITLE
Fix asset 404s by using a relative Vite base

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,5 +5,7 @@ import react from '@vitejs/plugin-react'
 // Example: base: '/hoops-hub-murray-bridge/'
 export default defineConfig({
   plugins: [react()],
-  base: '/hoops-hub-murray-bridge/'
+  // Use a relative base so that the built assets can be found regardless of
+  // the hosting path (e.g. GitHub Pages project sites or custom domains).
+  base: './'
 })


### PR DESCRIPTION
## Summary
- switch the Vite `base` configuration to a relative path so built assets resolve regardless of hosting path
- document the reason for using a relative base in the config file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e370ad4a0883278628b92f8501cea3